### PR TITLE
threadstore: make apis return errors

### DIFF
--- a/threadservice/threadservice.go
+++ b/threadservice/threadservice.go
@@ -32,7 +32,7 @@ type Threadservice interface {
 	Pull(ctx context.Context, id thread.ID, lid peer.ID, offset cid.Cid, opts ...PullOption) ([]thread.Record, error)
 
 	// Logs returns info for each log in the given thread.
-	Logs(id thread.ID) []thread.LogInfo
+	Logs(id thread.ID) ([]thread.LogInfo, error)
 
 	// Delete a thread.
 	Delete(ctx context.Context, id thread.ID) error

--- a/threadstore/threadstore.go
+++ b/threadstore/threadstore.go
@@ -24,11 +24,11 @@ type Threadstore interface {
 	AddrBook
 	HeadBook
 
-	Threads() thread.IDSlice
-	ThreadInfo(thread.ID) thread.Info
+	Threads() (thread.IDSlice, error)
+	ThreadInfo(thread.ID) (thread.Info, error)
 
 	AddLog(thread.ID, thread.LogInfo) error
-	LogInfo(thread.ID, peer.ID) thread.LogInfo
+	LogInfo(thread.ID, peer.ID) (thread.LogInfo, error)
 }
 
 // ThreadMetadata stores local thread metadata like name.

--- a/threadstore/threadstore.go
+++ b/threadstore/threadstore.go
@@ -33,58 +33,62 @@ type Threadstore interface {
 
 // ThreadMetadata stores local thread metadata like name.
 type ThreadMetadata interface {
-	GetMeta(t thread.ID, key string) (interface{}, error)
-	PutMeta(t thread.ID, key string, val interface{}) error
+	GetInt64(t thread.ID, key string) (*int64, error)
+	PutInt64(t thread.ID, key string, val int64) error
+	GetString(t thread.ID, key string) (*string, error)
+	PutString(t thread.ID, key string, val string) error
+	GetBytes(t thread.ID, key string) (*[]byte, error)
+	PutBytes(t thread.ID, key string, val []byte) error
 }
 
 // KeyBook stores log keys.
 type KeyBook interface {
-	PubKey(thread.ID, peer.ID) ic.PubKey
+	PubKey(thread.ID, peer.ID) (ic.PubKey, error)
 	AddPubKey(thread.ID, peer.ID, ic.PubKey) error
 
-	PrivKey(thread.ID, peer.ID) ic.PrivKey
+	PrivKey(thread.ID, peer.ID) (ic.PrivKey, error)
 	AddPrivKey(thread.ID, peer.ID, ic.PrivKey) error
 
-	ReadKey(thread.ID, peer.ID) []byte
+	ReadKey(thread.ID, peer.ID) ([]byte, error)
 	AddReadKey(thread.ID, peer.ID, []byte) error
 
-	FollowKey(thread.ID, peer.ID) []byte
+	FollowKey(thread.ID, peer.ID) ([]byte, error)
 	AddFollowKey(thread.ID, peer.ID, []byte) error
 
-	LogsWithKeys(thread.ID) peer.IDSlice
+	LogsWithKeys(thread.ID) (peer.IDSlice, error)
 
-	ThreadsFromKeys() thread.IDSlice
+	ThreadsFromKeys() (thread.IDSlice, error)
 }
 
 // AddrBook stores log addresses.
 type AddrBook interface {
-	AddAddr(thread.ID, peer.ID, ma.Multiaddr, time.Duration)
-	AddAddrs(thread.ID, peer.ID, []ma.Multiaddr, time.Duration)
+	AddAddr(thread.ID, peer.ID, ma.Multiaddr, time.Duration) error
+	AddAddrs(thread.ID, peer.ID, []ma.Multiaddr, time.Duration) error
 
-	SetAddr(thread.ID, peer.ID, ma.Multiaddr, time.Duration)
-	SetAddrs(thread.ID, peer.ID, []ma.Multiaddr, time.Duration)
+	SetAddr(thread.ID, peer.ID, ma.Multiaddr, time.Duration) error
+	SetAddrs(thread.ID, peer.ID, []ma.Multiaddr, time.Duration) error
 
-	UpdateAddrs(t thread.ID, id peer.ID, oldTTL time.Duration, newTTL time.Duration)
-	Addrs(thread.ID, peer.ID) []ma.Multiaddr
+	UpdateAddrs(t thread.ID, id peer.ID, oldTTL time.Duration, newTTL time.Duration) error
+	Addrs(thread.ID, peer.ID) ([]ma.Multiaddr, error)
 
-	AddrStream(context.Context, thread.ID, peer.ID) <-chan ma.Multiaddr
+	AddrStream(context.Context, thread.ID, peer.ID) (<-chan ma.Multiaddr, error)
 
-	ClearAddrs(thread.ID, peer.ID)
+	ClearAddrs(thread.ID, peer.ID) error
 
-	LogsWithAddrs(thread.ID) peer.IDSlice
+	LogsWithAddrs(thread.ID) (peer.IDSlice, error)
 
-	ThreadsFromAddrs() thread.IDSlice
+	ThreadsFromAddrs() (thread.IDSlice, error)
 }
 
 // HeadBook stores log heads.
 type HeadBook interface {
-	AddHead(thread.ID, peer.ID, cid.Cid)
-	AddHeads(thread.ID, peer.ID, []cid.Cid)
+	AddHead(thread.ID, peer.ID, cid.Cid) error
+	AddHeads(thread.ID, peer.ID, []cid.Cid) error
 
-	SetHead(thread.ID, peer.ID, cid.Cid)
-	SetHeads(thread.ID, peer.ID, []cid.Cid)
+	SetHead(thread.ID, peer.ID, cid.Cid) error
+	SetHeads(thread.ID, peer.ID, []cid.Cid) error
 
-	Heads(thread.ID, peer.ID) []cid.Cid
+	Heads(thread.ID, peer.ID) ([]cid.Cid, error)
 
-	ClearHeads(thread.ID, peer.ID)
+	ClearHeads(thread.ID, peer.ID) error
 }


### PR DESCRIPTION
This is an API change to consider errors in most Books APIs, since datastore backed books can have errors at most kind of actions.

This PR is a pre-requisite to possibly merge a pending  [`go-textile-threads` PR](https://github.com/textileio/go-textile-threads/pull/21).

I'll change from Draft when [`go-textile-threads` #15](https://github.com/textileio/go-textile-threads/pull/15)  gets merged.