### PR TITLE
Better Threads API

### DIFF
--- a/broadcast/broadcast.go
+++ b/broadcast/broadcast.go
@@ -83,7 +83,11 @@ func (b *Broadcaster) SendWithTimeout(v interface{}, timeout time.Duration) erro
 			result = multierror.Append(result, errors.New(err))
 		}
 	}
-	return result.ErrorOrNil()
+	if result != nil {
+		return result.ErrorOrNil()
+	} else {
+		return nil
+	}
 }
 
 // Send broadcasts a message to each listener's channel.

--- a/broadcast/broadcast.go
+++ b/broadcast/broadcast.go
@@ -138,7 +138,7 @@ func (l *Listener) Discard() {
 	delete(l.b.listeners, l.id)
 }
 
-// Channel returns the channel that receives broadcast messages
+// Channel returns the channel that receives broadcast messages.
 func (l *Listener) Channel() <-chan interface{} {
 	return l.ch
 }

--- a/broadcast/broadcast_test.go
+++ b/broadcast/broadcast_test.go
@@ -42,7 +42,7 @@ func TestSend(t *testing.T) {
 		wg.Done()
 	})
 	wg.Add(N)
-	b.Send(testStr)
+	_ = b.Send(testStr)
 	wg.Wait()
 }
 
@@ -73,9 +73,11 @@ func TestListenAndSendOnClosed(t *testing.T) {
 	b.Listen()
 	err := b.Send(testStr)
 	if err != ErrClosedChannel {
-		t.Errorf("Test should raise closed channel error: %s", err.Error())
+		if err != nil {
+			t.Errorf("Test should raise closed channel error: %s", err.Error())
+		}
 	}
-	if err.Error() != "send after close" {
+	if err == nil || err.Error() != "send after close" {
 		t.Error("Test should raise `send after close`")
 	}
 }
@@ -86,9 +88,11 @@ func TestListenAndSendOnCloseWithTimeout(t *testing.T) {
 	b.Listen()
 	err := b.SendWithTimeout(testStr, 0)
 	if err != ErrClosedChannel {
-		t.Errorf("Test should raise closed channel error: %s", err.Error())
+		if err != nil {
+			t.Errorf("Test should raise closed channel error: %s", err.Error())
+		}
 	}
-	if err.Error() != "send after close" {
+	if err == nil || err.Error() != "send after close" {
 		t.Error("Test should raise `send after close`")
 	}
 }
@@ -130,7 +134,7 @@ func TestBroadcasterClose(t *testing.T) {
 		l := b.Listen()
 		wg.Done()
 		select {
-		case _, ok := (<-l.Channel()):
+		case _, ok := <-l.Channel():
 			if ok {
 				t.Error("receive after close")
 			}
@@ -164,6 +168,6 @@ func TestListenerClose(t *testing.T) {
 		wg.Done()
 	})
 	wg.Add(N)
-	b.Send(testStr)
+	_ = b.Send(testStr)
 	wg.Wait()
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -10,13 +10,18 @@ import (
 
 // EncryptionKey represents a key that can be used for encryption.
 type EncryptionKey interface {
+	// Encrypt bytes.
 	Encrypt([]byte) ([]byte, error)
+
+	// Marshal to bytes.
 	Marshal() ([]byte, error)
 }
 
 // EncryptionKey represents a key that can be used for decryption.
 type DecryptionKey interface {
 	EncryptionKey
+
+	// Decrypt bytes.
 	Decrypt([]byte) ([]byte, error)
 }
 

--- a/threadservice/options.go
+++ b/threadservice/options.go
@@ -113,33 +113,3 @@ func PutOptions(opts ...PutOption) *PutSettings {
 	}
 	return options
 }
-
-// PullOpt is an instance helper for creating pull options.
-var PullOpt PullOption
-
-// PullOption is used to create PullSettings.
-type PullOption func(*PullSettings)
-
-// Limit sets the upper limit of nodes to return during a pull operation.
-func (PullOption) Limit(val int) PullOption {
-	return func(settings *PullSettings) {
-		settings.Limit = val
-	}
-}
-
-// PullSettings holds values used for a pull operation.
-type PullSettings struct {
-	Limit int
-}
-
-// PullOptions returns pull settings from options.
-func PullOptions(opts ...PullOption) *PullSettings {
-	options := &PullSettings{
-		Limit: -1,
-	}
-
-	for _, opt := range opts {
-		opt(options)
-	}
-	return options
-}

--- a/threadservice/options.go
+++ b/threadservice/options.go
@@ -15,10 +15,10 @@ var AddOpt AddOption
 // AddOption is used to create AddSettings.
 type AddOption func(*AddSettings)
 
-// Thread sets the target thread for an add operation.
-func (AddOption) Thread(val thread.ID) AddOption {
+// ThreadID sets the target thread for an add operation.
+func (AddOption) ThreadID(val thread.ID) AddOption {
 	return func(settings *AddSettings) {
-		settings.Thread = val
+		settings.ThreadID = val
 	}
 }
 
@@ -56,18 +56,18 @@ func (AddOption) Addrs(val []ma.Multiaddr) AddOption {
 
 // AddSettings holds values used for an add operation.
 type AddSettings struct {
-	Thread thread.ID
-	Time   time.Time
-	Key    crypto.EncryptionKey
-	KeyLog peer.ID
-	Addrs  []ma.Multiaddr
+	ThreadID thread.ID
+	Time     time.Time
+	Key      crypto.EncryptionKey
+	KeyLog   peer.ID
+	Addrs    []ma.Multiaddr
 }
 
 // AddOptions returns add settings from options.
 func AddOptions(opts ...AddOption) *AddSettings {
 	options := &AddSettings{
-		Thread: thread.NewIDV1(thread.AccessControlled, 16),
-		Time:   time.Now(),
+		ThreadID: thread.NewIDV1(thread.AccessControlled, 16),
+		Time:     time.Now(),
 	}
 
 	for _, opt := range opts {
@@ -82,30 +82,30 @@ var PutOpt PutOption
 // PutOption is used to create PutSettings.
 type PutOption func(*PutSettings)
 
-// Thread sets the target thread for a put operation.
-func (PutOption) Thread(val thread.ID) PutOption {
+// ThreadID sets the target thread for a put operation.
+func (PutOption) ThreadID(val thread.ID) PutOption {
 	return func(settings *PutSettings) {
-		settings.Thread = val
+		settings.ThreadID = val
 	}
 }
 
-// Log sets the target log for a put operation.
-func (PutOption) Log(val peer.ID) PutOption {
+// LogID sets the target log for a put operation.
+func (PutOption) LogID(val peer.ID) PutOption {
 	return func(settings *PutSettings) {
-		settings.Log = val
+		settings.LogID = val
 	}
 }
 
 // PutSettings holds values used for a put operation.
 type PutSettings struct {
-	Thread thread.ID
-	Log    peer.ID
+	ThreadID thread.ID
+	LogID    peer.ID
 }
 
 // PutOptions returns put settings from options.
 func PutOptions(opts ...PutOption) *PutSettings {
 	options := &PutSettings{
-		Thread: thread.NewIDV1(thread.AccessControlled, 16),
+		ThreadID: thread.NewIDV1(thread.AccessControlled, 16),
 	}
 
 	for _, opt := range opts {
@@ -120,18 +120,18 @@ var ListenOpt ListenOption
 // ListenOption is used to create ListenSettings.
 type ListenOption func(*ListenSettings)
 
-// Thread restricts the listener to the given thread.
+// ThreadID restricts the listener to the given thread.
 // Use this option multiple times to build up a list of threads
 // to listen to.
-func (ListenOption) Thread(val thread.ID) ListenOption {
+func (ListenOption) ThreadID(val thread.ID) ListenOption {
 	return func(settings *ListenSettings) {
-		settings.Threads = append(settings.Threads, val)
+		settings.ThreadIDs = append(settings.ThreadIDs, val)
 	}
 }
 
 // ListenSettings holds values used for a listen operation.
 type ListenSettings struct {
-	Threads []thread.ID
+	ThreadIDs []thread.ID
 }
 
 // ListenOptions returns listen settings from options.

--- a/threadservice/options.go
+++ b/threadservice/options.go
@@ -113,3 +113,33 @@ func PutOptions(opts ...PutOption) *PutSettings {
 	}
 	return options
 }
+
+// ListenOpt is an instance helper for creating listen options.
+var ListenOpt ListenOption
+
+// ListenOption is used to create ListenSettings.
+type ListenOption func(*ListenSettings)
+
+// Thread restricts the listener to the given thread.
+// Use this option multiple times to build up a list of threads
+// to listen to.
+func (ListenOption) Thread(val thread.ID) ListenOption {
+	return func(settings *ListenSettings) {
+		settings.Threads = append(settings.Threads, val)
+	}
+}
+
+// ListenSettings holds values used for a listen operation.
+type ListenSettings struct {
+	Threads []thread.ID
+}
+
+// ListenOptions returns listen settings from options.
+func ListenOptions(opts ...ListenOption) *ListenSettings {
+	options := &ListenSettings{}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+	return options
+}

--- a/threadservice/threadservice.go
+++ b/threadservice/threadservice.go
@@ -40,7 +40,7 @@ type Threadservice interface {
 	Pull(ctx context.Context, id thread.ID) error
 
 	// GetLogs returns info about the logs in the given thread.
-	GetLogs(id thread.ID) []thread.LogInfo
+	GetLogs(id thread.ID) ([]thread.LogInfo, error)
 
 	// Delete the given thread.
 	Delete(ctx context.Context, id thread.ID) error

--- a/threadservice/threadservice.go
+++ b/threadservice/threadservice.go
@@ -16,24 +16,39 @@ type Threadservice interface {
 	// Threadstore persists thread log details.
 	tstore.Threadstore
 
-	// Host provides a network identity.
+	// Host provides a network listener identity.
 	Host() host.Host
 
 	// DAGService provides a DAG API for reading and writing thread logs.
 	DAGService() format.DAGService
 
-	// Add data to a thread. Creates a new thread and own log if they don't exist.
-	Add(ctx context.Context, body format.Node, opts ...AddOption) (peer.ID, thread.Record, error)
+	// Add a new record by wrapping body. See AddOption for more.
+	Add(ctx context.Context, body format.Node, opts ...AddOption) (*Record, error)
 
-	// Put an existing node to a log.
+	// Put an existing record. See PutOption for more.
 	Put(ctx context.Context, node thread.Record, opts ...PutOption) error
 
-	// Pull paginates thread log events.
-	Pull(ctx context.Context, id thread.ID, lid peer.ID, offset cid.Cid, opts ...PullOption) ([]thread.Record, error)
+	// Get returns the record at cid.
+	Get(ctx context.Context, id thread.ID, lid peer.ID, rid cid.Cid) (thread.Record, error)
 
-	// Logs returns info for each log in the given thread.
-	Logs(id thread.ID) ([]thread.LogInfo, error)
+	// Updates returns a read-only channel of updates.
+	Updates() <-chan *Record
 
-	// Delete a thread.
+	// Pull for new records from the given thread.
+	// Logs owned by this host are traversed locally.
+	// Remotely addressed logs are pulled from the network.
+	Pull(ctx context.Context, id thread.ID) error
+
+	// GetLogs returns info about the logs in the given thread.
+	GetLogs(id thread.ID) []thread.LogInfo
+
+	// Delete the given thread.
 	Delete(ctx context.Context, id thread.ID) error
+}
+
+// Record is used to wrap a thread.Record with its thread and log context.
+type Record struct {
+	ThreadID thread.ID
+	LogID    peer.ID
+	Record   thread.Record
 }

--- a/threadservice/threadservice.go
+++ b/threadservice/threadservice.go
@@ -23,7 +23,7 @@ type Threadservice interface {
 	DAGService() format.DAGService
 
 	// Add a new record by wrapping body. See AddOption for more.
-	Add(ctx context.Context, body format.Node, opts ...AddOption) (*Record, error)
+	Add(ctx context.Context, body format.Node, opts ...AddOption) (Record, error)
 
 	// Put an existing record. See PutOption for more.
 	Put(ctx context.Context, node thread.Record, opts ...PutOption) error
@@ -31,8 +31,8 @@ type Threadservice interface {
 	// Get returns the record at cid.
 	Get(ctx context.Context, id thread.ID, lid peer.ID, rid cid.Cid) (thread.Record, error)
 
-	// Updates returns a read-only channel of updates.
-	Updates() <-chan *Record
+	// Listen returns a read-only channel of records.
+	Listen(opts ...ListenOption) RecordListener
 
 	// Pull for new records from the given thread.
 	// Logs owned by this host are traversed locally.
@@ -46,9 +46,23 @@ type Threadservice interface {
 	Delete(ctx context.Context, id thread.ID) error
 }
 
-// Record is used to wrap a thread.Record with its thread and log context.
-type Record struct {
-	ThreadID thread.ID
-	LogID    peer.ID
-	Record   thread.Record
+// RecordListener receives thread record updates.
+type RecordListener interface {
+	// Discard closes the listener, disabling the reception of further records.
+	Discard()
+
+	// Channel returns the channel that receives broadcast records.
+	Channel() <-chan Record
+}
+
+// Record wraps a thread.Record within a thread and log context.
+type Record interface {
+	// Value returns the underlying record.
+	Value() thread.Record
+
+	// ThreadID returns the record's thread ID.
+	ThreadID() thread.ID
+
+	// LogID returns the record's log ID.
+	LogID() peer.ID
 }

--- a/threadstore/threadstore.go
+++ b/threadstore/threadstore.go
@@ -24,71 +24,123 @@ type Threadstore interface {
 	AddrBook
 	HeadBook
 
+	// Threads returns all threads in the store.
 	Threads() (thread.IDSlice, error)
+
+	// ThreadInfo returns info about a thread.
 	ThreadInfo(thread.ID) (thread.Info, error)
 
+	// AddLog adds a log to a thread.
 	AddLog(thread.ID, thread.LogInfo) error
+
+	// LogInfo returns info about a log.
 	LogInfo(thread.ID, peer.ID) (thread.LogInfo, error)
 }
 
 // ThreadMetadata stores local thread metadata like name.
 type ThreadMetadata interface {
+	// GetInt64 retrieves a string value under key.
 	GetInt64(t thread.ID, key string) (*int64, error)
+
+	// PutInt64 stores an int value under key.
 	PutInt64(t thread.ID, key string, val int64) error
+
+	// GetString retrieves an int value under key.
 	GetString(t thread.ID, key string) (*string, error)
+
+	// PutString stores a string value under key.
 	PutString(t thread.ID, key string, val string) error
+
+	// GetBytes retrieves a byte value under key.
 	GetBytes(t thread.ID, key string) (*[]byte, error)
+
+	// PutBytes stores a byte value under key.
 	PutBytes(t thread.ID, key string, val []byte) error
 }
 
 // KeyBook stores log keys.
 type KeyBook interface {
+	// PubKey retrieves the public key of a log.
 	PubKey(thread.ID, peer.ID) (ic.PubKey, error)
+
+	// AddPubKey adds a public key under a log.
 	AddPubKey(thread.ID, peer.ID, ic.PubKey) error
 
+	// PrivKey retrieves the private key of a log.
 	PrivKey(thread.ID, peer.ID) (ic.PrivKey, error)
+
+	// AddPrivKey adds a private key under a log.
 	AddPrivKey(thread.ID, peer.ID, ic.PrivKey) error
 
+	// ReadKey retrieves the read key of a log.
 	ReadKey(thread.ID, peer.ID) ([]byte, error)
+
+	// AddReadKey adds a read key under a log.
 	AddReadKey(thread.ID, peer.ID, []byte) error
 
+	// FollowKey retrieves the follow key of a log.
 	FollowKey(thread.ID, peer.ID) ([]byte, error)
+
+	// AddFollowKey adds a follow key under a log.
 	AddFollowKey(thread.ID, peer.ID, []byte) error
 
+	// LogsWithKeys returns a list of log IDs for a thread.
 	LogsWithKeys(thread.ID) (peer.IDSlice, error)
 
+	// ThreadsFromKeys returns a list of threads referenced in the book.
 	ThreadsFromKeys() (thread.IDSlice, error)
 }
 
 // AddrBook stores log addresses.
 type AddrBook interface {
+	// AddAddr adds an address under a log with a given TTL.
 	AddAddr(thread.ID, peer.ID, ma.Multiaddr, time.Duration) error
+
+	// AddAddrs adds addresses under a log with a given TTL.
 	AddAddrs(thread.ID, peer.ID, []ma.Multiaddr, time.Duration) error
 
+	// SetAddr sets a log's address with a given TTL.
 	SetAddr(thread.ID, peer.ID, ma.Multiaddr, time.Duration) error
+
+	// SetAddrs sets a log's addresses with a given TTL.
 	SetAddrs(thread.ID, peer.ID, []ma.Multiaddr, time.Duration) error
 
+	// UpdateAddrs updates the TTL of a log address.
 	UpdateAddrs(t thread.ID, id peer.ID, oldTTL time.Duration, newTTL time.Duration) error
+
+	// Addrs returns all addresses for a log.
 	Addrs(thread.ID, peer.ID) ([]ma.Multiaddr, error)
 
+	// AddrStream returns a channel that delivers address changes for a log.
 	AddrStream(context.Context, thread.ID, peer.ID) (<-chan ma.Multiaddr, error)
 
+	// ClearAddrs deletes all addresses for a log.
 	ClearAddrs(thread.ID, peer.ID) error
 
+	// LogsWithAddrs returns a list of log IDs for a thread.
 	LogsWithAddrs(thread.ID) (peer.IDSlice, error)
 
+	// ThreadsFromAddrs returns a list of threads referenced in the book.
 	ThreadsFromAddrs() (thread.IDSlice, error)
 }
 
 // HeadBook stores log heads.
 type HeadBook interface {
+	// AddHead stores cid in a log's head.
 	AddHead(thread.ID, peer.ID, cid.Cid) error
+
+	// AddHeads stores cids in a log's head.
 	AddHeads(thread.ID, peer.ID, []cid.Cid) error
 
+	// SetHead sets a log's head as cid.
 	SetHead(thread.ID, peer.ID, cid.Cid) error
+
+	// SetHeads sets a log's head as cids.
 	SetHeads(thread.ID, peer.ID, []cid.Cid) error
 
+	// Heads retrieves head values for a log.
 	Heads(thread.ID, peer.ID) ([]cid.Cid, error)
 
+	// ClearHeads deletes the head entry for a log.
 	ClearHeads(thread.ID, peer.ID) error
 }


### PR DESCRIPTION
- Removes Pull options
- Adds Listen options
- Pull is now at the thread level
- Adds a Listen method which allows users to consume thread record updates as they are written locally or remotely
- Adds broadcaster package

Related to https://github.com/textileio/go-textile-threads/