### PR TITLE
Non-blocking broadcaster

### DIFF
--- a/broadcast/broadcast.go
+++ b/broadcast/broadcast.go
@@ -1,0 +1,141 @@
+// Package broadcast implements multi-listener broadcast channels.
+// See https://godoc.org/github.com/tjgq/broadcast for original implementation.
+//
+// To create an un-buffered broadcast channel, just declare a Broadcaster:
+//
+//     var b broadcast.Broadcaster
+//
+// To create a buffered broadcast channel with capacity n, call New:
+//
+//     b := broadcast.New(n)
+//
+// To add a listener to a channel, call Listen and read from Channel():
+//
+//     l := b.Listen()
+//     for v := range l.Channel() {
+//         // ...
+//     }
+//
+//
+// To send to the channel, call Send:
+//
+//     b.Send("Hello world!")
+//     v <- l.Channel() // returns interface{}("Hello world!")
+//
+// To remove a listener, call Discard.
+//
+//     l.Discard()
+//
+// To close the broadcast channel, call Discard. Any existing or future listeners
+// will read from a closed channel:
+//
+//     b.Discard()
+//     v, ok <- l.Channel() // returns ok == false
+package broadcast
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// ErrClosedChannel means the caller attempted to send to one or more closed broadcast channels.
+const ErrClosedChannel = broadcastError("send after close")
+
+type broadcastError string
+
+func (e broadcastError) Error() string { return string(e) }
+
+// Broadcaster implements a Publisher. The zero value is a usable un-buffered channel.
+type Broadcaster struct {
+	m         sync.Mutex
+	listeners map[uint]chan<- interface{} // lazy init
+	nextID    uint
+	capacity  int
+	closed    bool
+}
+
+// NewBroadcaster returns a new Broadcaster with the given capacity (0 means un-buffered).
+func NewBroadcaster(n int) *Broadcaster {
+	return &Broadcaster{capacity: n}
+}
+
+// SendWithTimeout broadcasts a message to each listener's channel.
+// Sending on a closed channel causes a runtime panic.
+// This method blocks for a duration of up to `timeout` on each channel.
+// Returns error(s) if it is unable to send on a given listener's channel within `timeout` duration.
+func (b *Broadcaster) SendWithTimeout(v interface{}, timeout time.Duration) error {
+	b.m.Lock()
+	defer b.m.Unlock()
+	if b.closed {
+		return ErrClosedChannel
+	}
+	var result *multierror.Error
+	for id, l := range b.listeners {
+		select {
+		case l <- v:
+			// Success!
+		case <-time.After(timeout):
+			err := fmt.Sprintf("unable to send to listener '%d'", id)
+			result = multierror.Append(result, errors.New(err))
+		}
+	}
+	return result.ErrorOrNil()
+}
+
+// Send broadcasts a message to each listener's channel.
+// Sending on a closed channel causes a runtime panic.
+// This method is non-blocking, and will return errors if unable to send on a given listener's channel.
+func (b *Broadcaster) Send(v interface{}) error {
+	return b.SendWithTimeout(v, 0)
+}
+
+// Discard closes the channel, disabling the sending of further messages.
+func (b *Broadcaster) Discard() {
+	b.m.Lock()
+	defer b.m.Unlock()
+	b.closed = true
+	for _, l := range b.listeners {
+		close(l)
+	}
+}
+
+// Listen returns a Listener for the broadcast channel.
+func (b *Broadcaster) Listen() *Listener {
+	b.m.Lock()
+	defer b.m.Unlock()
+	if b.listeners == nil {
+		b.listeners = make(map[uint]chan<- interface{})
+	}
+	if b.listeners[b.nextID] != nil {
+		b.nextID++
+	}
+	ch := make(chan interface{}, b.capacity)
+	if b.closed {
+		close(ch)
+	}
+	b.listeners[b.nextID] = ch
+	return &Listener{ch, b, b.nextID}
+}
+
+// Listener implements a Subscriber to broadcast channel.
+type Listener struct {
+	ch <-chan interface{}
+	b  *Broadcaster
+	id uint
+}
+
+// Discard closes the Listener, disabling the reception of further messages.
+func (l *Listener) Discard() {
+	l.b.m.Lock()
+	defer l.b.m.Unlock()
+	delete(l.b.listeners, l.id)
+}
+
+// Channel returns the channel that receives broadcast messages
+func (l *Listener) Channel() <-chan interface{} {
+	return l.ch
+}

--- a/broadcast/broadcast.go
+++ b/broadcast/broadcast.go
@@ -97,6 +97,9 @@ func (b *Broadcaster) Send(v interface{}) error {
 func (b *Broadcaster) Discard() {
 	b.m.Lock()
 	defer b.m.Unlock()
+	if b.closed {
+		return
+	}
 	b.closed = true
 	for _, l := range b.listeners {
 		close(l)

--- a/broadcast/broadcast_test.go
+++ b/broadcast/broadcast_test.go
@@ -1,0 +1,169 @@
+package broadcast
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+const (
+	N       = 3
+	testStr = "Test"
+	timeout = time.Second
+)
+
+type ListenFunc func(int, *Broadcaster, *sync.WaitGroup)
+
+func setupN(f ListenFunc) (*Broadcaster, *sync.WaitGroup) {
+	var b Broadcaster
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go f(i, &b, &wg)
+	}
+	wg.Wait()
+	return &b, &wg
+}
+
+func TestSend(t *testing.T) {
+	b, wg := setupN(func(i int, b *Broadcaster, wg *sync.WaitGroup) {
+		l := b.Listen()
+		wg.Done()
+		select {
+		case v := <-l.Channel():
+			if v.(string) != testStr {
+				t.Error("bad value received")
+			}
+		case <-time.After(timeout):
+			t.Error("receive timed out")
+		}
+		wg.Done()
+	})
+	wg.Add(N)
+	b.Send(testStr)
+	wg.Wait()
+}
+
+func TestSendError(t *testing.T) {
+	var b Broadcaster
+	// Register listeners, but do not consume
+	b.Listen()
+	b.Listen()
+	b.Listen()
+	if err := b.Send(testStr); err == nil {
+		t.Error("should error when no consumers")
+		if multi, ok := err.(*multierror.Error); ok {
+			if len(multi.Errors) != 3 {
+				t.Error("expected 3 errors")
+			}
+		} else {
+			t.Error("expected a multi-error")
+		}
+	}
+	if err := b.Send(testStr); err == nil {
+		t.Error("should error when no consumers")
+	}
+}
+
+func TestListenAndSendOnClosed(t *testing.T) {
+	var b = NewBroadcaster(5)
+	b.Discard()
+	b.Listen()
+	err := b.Send(testStr)
+	if err != ErrClosedChannel {
+		t.Errorf("Test should raise closed channel error: %s", err.Error())
+	}
+	if err.Error() != "send after close" {
+		t.Error("Test should raise `send after close`")
+	}
+}
+
+func TestListenAndSendOnCloseWithTimeout(t *testing.T) {
+	var b = NewBroadcaster(5)
+	b.Discard()
+	b.Listen()
+	err := b.SendWithTimeout(testStr, 0)
+	if err != ErrClosedChannel {
+		t.Errorf("Test should raise closed channel error: %s", err.Error())
+	}
+	if err.Error() != "send after close" {
+		t.Error("Test should raise `send after close`")
+	}
+}
+
+func TestSendWithTimeout(t *testing.T) {
+	var b Broadcaster
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(i int, b *Broadcaster, wg *sync.WaitGroup) {
+		l := b.Listen()
+		wg.Done()
+		time.Sleep(time.Second)
+		select {
+		case v := <-l.Channel():
+			if v.(string) != testStr {
+				t.Error("bad value received")
+			}
+		case <-time.After(timeout):
+			t.Error("receive timed out")
+		}
+		wg.Done()
+	}(1, &b, &wg)
+	wg.Wait()
+	wg.Add(1)
+	if err := b.Send(testStr); err == nil {
+		t.Error("should error")
+	}
+	if err := b.SendWithTimeout(testStr, 0); err == nil {
+		t.Error("should error within 1 second")
+	}
+	if err := b.SendWithTimeout(testStr, 2*time.Second); err != nil {
+		t.Error("should not error within 2 seconds")
+	}
+	wg.Wait()
+}
+
+func TestBroadcasterClose(t *testing.T) {
+	b, wg := setupN(func(i int, b *Broadcaster, wg *sync.WaitGroup) {
+		l := b.Listen()
+		wg.Done()
+		select {
+		case _, ok := (<-l.Channel()):
+			if ok {
+				t.Error("receive after close")
+			}
+		case <-time.After(timeout):
+			t.Error("receive timed out")
+		}
+		wg.Done()
+	})
+	wg.Add(N)
+	b.Discard()
+	wg.Wait()
+}
+
+func TestListenerClose(t *testing.T) {
+	b, wg := setupN(func(i int, b *Broadcaster, wg *sync.WaitGroup) {
+		l := b.Listen()
+		if i == 0 {
+			l.Discard()
+		}
+		wg.Done()
+		select {
+		case <-l.Channel():
+			if i == 0 {
+				t.Error("receive after close")
+			}
+		case <-time.After(timeout):
+			if i != 0 {
+				t.Error("receive timed out")
+			}
+		}
+		wg.Done()
+	})
+	wg.Add(N)
+	b.Send(testStr)
+	wg.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412
 	github.com/golang/protobuf v1.3.1
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/ipfs/go-cid v0.0.3
 	github.com/ipfs/go-ipld-format v0.0.2
 	github.com/libp2p/go-libp2p-core v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,10 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
+github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ipfs/go-block-format v0.0.2 h1:qPDvcP19izTjU8rgo6p7gTXZlkMkF5bz5G3fqIsSCPE=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=


### PR DESCRIPTION
### Issue or RFC Endorsed by Textile's Maintainers

Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

### Description of the Change

This improvement was inspired by some comments by @jsign on Slack relating to slow consumers blocking the broadcaster. He suggested a timeout, which this PR also supports. It also necessarily improves test coverage to test these new features.

This was originally implemented in a separate package, and was reviewed previously by @jsign who made useful suggestions to improve the original implementation.

### Alternate Designs

We could have gone with a default timeout, but this felt more useful potentially. It also uses [multi-errors](https://godoc.org/github.com/hashicorp/go-multierror), which seemed like a really nice enhancement (also inspired by a comment by @jsign).

### Possible Drawbacks

We'll have to decide is a non-blocking broadcaster is indeed what we want elsewhere.

### Verification Process

New tests were added to verify the new feature is doing what it claims to be doing.

### Release Notes

Broadcaster is now non-blocking, and will return a [multierror](https://godoc.org/github.com/hashicorp/go-multierror) if it is unable to broadcast to given channel(s). Test coverage for broadcaster was increased to 100%.