### PR TITLE
Add thread w/ follower and read keys

### DIFF
--- a/thread/thread.go
+++ b/thread/thread.go
@@ -306,17 +306,17 @@ func (s IDSlice) Less(i, j int) bool { return s[i].str < s[j].str }
 
 // Info holds a thread ID associated known logs.
 type Info struct {
-	ID   ID
-	Logs peer.IDSlice
+	ID        ID
+	Logs      peer.IDSlice
+	FollowKey *sym.Key
+	ReadKey   *sym.Key
 }
 
 // LogInfo holds known info about a log.
 type LogInfo struct {
-	ID        peer.ID
-	PubKey    ic.PubKey
-	PrivKey   ic.PrivKey
-	FollowKey *sym.Key
-	ReadKey   *sym.Key
-	Addrs     []ma.Multiaddr
-	Heads     []cid.Cid
+	ID      peer.ID
+	PubKey  ic.PubKey
+	PrivKey ic.PrivKey
+	Addrs   []ma.Multiaddr
+	Heads   []cid.Cid
 }

--- a/threadservice/threadservice.go
+++ b/threadservice/threadservice.go
@@ -9,6 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	ma "github.com/multiformats/go-multiaddr"
+	sym "github.com/textileio/go-textile-core/crypto/symmetric"
 	"github.com/textileio/go-textile-core/thread"
 	tstore "github.com/textileio/go-textile-core/threadstore"
 )
@@ -27,7 +28,7 @@ type Threadservice interface {
 	Store() tstore.Threadstore
 
 	// AddThread from a multiaddress.
-	AddThread(ctx context.Context, addr ma.Multiaddr) (thread.Info, error)
+	AddThread(ctx context.Context, addr ma.Multiaddr, fk *sym.Key, rk *sym.Key) (thread.Info, error)
 
 	// PullThread for new records.
 	// Logs owned by this host are traversed locally.

--- a/threadstore/threadstore.go
+++ b/threadstore/threadstore.go
@@ -28,6 +28,9 @@ type Threadstore interface {
 	// Threads returns all threads in the store.
 	Threads() (thread.IDSlice, error)
 
+	// AddThread adds a thread.
+	AddThread(thread.Info) error
+
 	// ThreadInfo returns info about a thread.
 	ThreadInfo(thread.ID) (thread.Info, error)
 


### PR DESCRIPTION
This is needed to apply "back-channeled" keys to a new thread. Follow key is always required.