### PR TITLE
jwt: pull over ed25519 signing method from go-textile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.13
 
 require (
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412
-	github.com/golang/protobuf v1.3.1
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/golang/protobuf v1.3.2
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/ipfs/go-cid v0.0.3
@@ -13,6 +14,9 @@ require (
 	github.com/libp2p/go-libp2p-core v0.2.3
 	github.com/multiformats/go-multiaddr v0.1.1
 	github.com/multiformats/go-multibase v0.0.1
-	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392
-	google.golang.org/grpc v1.21.1
+	golang.org/x/crypto v0.0.0-20190926180335-cea2066c6411
+	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582 // indirect
+	golang.org/x/sys v0.0.0-20190926180325-855e68c8590b // indirect
+	google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 // indirect
+	google.golang.org/grpc v1.24.0
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495 h1:6IyqGr3fnd0tM3Y
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
@@ -31,6 +33,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
@@ -125,6 +129,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 h1:ACG4HJsFiNMf47Y4PeRoebLNy/2lXT9EtprMuTFWt1M=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
+golang.org/x/crypto v0.0.0-20190926180335-cea2066c6411 h1:kuW9k4QvBJpRjC3rxEytsfIYPs8oGY3Jw7iR36h0FIY=
+golang.org/x/crypto v0.0.0-20190926180335-cea2066c6411/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -139,11 +145,14 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2eP
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582 h1:p9xBe/w/OzkeYVKm234g55gMdD1nSIooTir5kV11kfA=
+golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -155,6 +164,8 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69 h1:rOhMmluY6kLMhdnrivzec6lLgaVbMHMn2ISQXJeJ5EM=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190926180325-855e68c8590b h1:/8GN4qrAmRZQXgjWZHj9z/UJI5vNqQhPtgcw02z2f+8=
+golang.org/x/sys v0.0.0-20190926180325-855e68c8590b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -165,6 +176,7 @@ golang.org/x/tools v0.0.0-20181130052023-1c3d964395ce/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -172,11 +184,13 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb h1:i1Ppqkc3WQXikh8bXiwHqAN5Rv3/qDCcRk0/Otx73BY=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
+google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 h1:nfPFGzJkUDX6uBmpN/pSw7MbOAWegH5QDQuoXFHedLg=
+google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/grpc v1.19.0 h1:cfg4PD8YEdSFnm7qLV4++93WcmhH2nIUhMjhdCvl3j8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
-google.golang.org/grpc v1.21.1 h1:j6XxA85m/6txkUCHvzlV5f+HBNl/1r5cZ2A/3IEFOO8=
-google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
+google.golang.org/grpc v1.24.0 h1:vb/1TCsVn3DcJlQ0Gs1yB1pKI6Do2/QNwxdKqmc/b0s=
+google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -186,3 +200,4 @@ gopkg.in/src-d/go-log.v1 v1.0.1/go.mod h1:GN34hKP0g305ysm2/hctJ0Y8nWP3zxXXJ8GFab
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -1,0 +1,75 @@
+package jwt
+
+import (
+	"github.com/dgrijalva/jwt-go"
+	"github.com/libp2p/go-libp2p-core/crypto"
+)
+
+// Implements the Ed25519 signing method
+// Expects *crypto.Ed25519PublicKey for signing and *crypto.Ed25519PublicKey for validation
+type SigningMethodEd25519 struct {
+	Name string
+}
+
+// Specific instance for Ed25519
+var SigningMethodEd25519i *SigningMethodEd25519
+
+func init() {
+	SigningMethodEd25519i = &SigningMethodEd25519{"Ed25519"}
+	jwt.RegisterSigningMethod(SigningMethodEd25519i.Alg(), func() jwt.SigningMethod {
+		return SigningMethodEd25519i
+	})
+}
+
+// Alg returns the name of this signing method
+func (m *SigningMethodEd25519) Alg() string {
+	return m.Name
+}
+
+// Implements the Verify method from SigningMethod
+// For this signing method, must be a *crypto.Ed25519PublicKey structure.
+func (m *SigningMethodEd25519) Verify(signingString, signature string, key interface{}) error {
+	var err error
+
+	// Decode the signature
+	var sig []byte
+	if sig, err = jwt.DecodeSegment(signature); err != nil {
+		return err
+	}
+
+	var ed25519Key *crypto.Ed25519PublicKey
+	var ok bool
+
+	if ed25519Key, ok = key.(*crypto.Ed25519PublicKey); !ok {
+		return jwt.ErrInvalidKeyType
+	}
+
+	// verify the signature
+	valid, err := ed25519Key.Verify([]byte(signingString), sig)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		return jwt.ErrSignatureInvalid
+	}
+
+	return nil
+}
+
+// Implements the Sign method from SigningMethod
+// For this signing method, must be a *crypto.Ed25519PublicKey structure.
+func (m *SigningMethodEd25519) Sign(signingString string, key interface{}) (string, error) {
+	var ed25519Key *crypto.Ed25519PrivateKey
+	var ok bool
+
+	// validate type of key
+	if ed25519Key, ok = key.(*crypto.Ed25519PrivateKey); !ok {
+		return "", jwt.ErrInvalidKey
+	}
+
+	sigBytes, err := ed25519Key.Sign([]byte(signingString))
+	if err != nil {
+		return "", err
+	}
+	return jwt.EncodeSegment(sigBytes), nil
+}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1,0 +1,111 @@
+package jwt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/libp2p/go-libp2p-core/crypto"
+)
+
+var publicKey = "CAESIP1G8uGFpX+iduqgJfKLt0nw870MI9ydHcKg9gDIr5Tb"
+var privateKey = "CAESYKcFG4UOHb1fyF+GlyGWfjfX47DH3y/K9fYMMMdy3Ow2/Uby4YWlf6J26qAl8ou3SfDzvQwj3J0dwqD2AMivlNv9RvLhhaV/onbqoCXyi7dJ8PO9DCPcnR3CoPYAyK+U2w=="
+
+var ed25519TestData = []struct {
+	name        string
+	tokenString string
+	alg         string
+	claims      map[string]interface{}
+	valid       bool
+}{
+	{
+		"Ed25519",
+		"eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJqdGkiOiJmb28iLCJzdWIiOiJiYXIifQ.E73qcBjcCSsYto_Pa5CpwZUu9lA3ecCVkZ8pJiFYNaOe2x-uZCDmZnx52AByO78oxft09GosVcJtqYNv1VBxDQ",
+		"Ed25519",
+		map[string]interface{}{"jti": "foo", "sub": "bar"},
+		true,
+	},
+	{
+		"invalid key",
+		"eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJqdGkiOiJmb28iLCJzdWIiOiJiYXIifQ.7FSQFedbbRl42nvUWJqBswvjmyMaBBLKk0opiARjxtZmQ86dVMYs5wcZ0gItVV8YLVu6F5065IFD699tVcacBA",
+		"Ed25519",
+		map[string]interface{}{"jti": "foo", "sub": "bar"},
+		false,
+	},
+}
+
+func TestSigningMethodEd25519_Alg(t *testing.T) {
+	if SigningMethodEd25519i.Alg() != "Ed25519" {
+		t.Fatal("wrong alg")
+	}
+}
+
+func TestSigningMethodEd25519_Sign(t *testing.T) {
+	sk, err := unmarshalPrivateKeyFromString(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, data := range ed25519TestData {
+		if data.valid {
+			parts := strings.Split(data.tokenString, ".")
+			method := jwt.GetSigningMethod(data.alg)
+			sig, err := method.Sign(strings.Join(parts[0:2], "."), sk)
+			if err != nil {
+				t.Errorf("[%v] error signing token: %v", data.name, err)
+			}
+			if sig != parts[2] {
+				t.Errorf("[%v] incorrect signature.\nwas:\n%v\nexpecting:\n%v", data.name, sig, parts[2])
+			}
+		}
+	}
+}
+
+func TestSigningMethodEd25519_Verify(t *testing.T) {
+	pk, err := unmarshalPublicKeyFromString(publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, data := range ed25519TestData {
+		parts := strings.Split(data.tokenString, ".")
+
+		method := jwt.GetSigningMethod(data.alg)
+		err := method.Verify(strings.Join(parts[0:2], "."), parts[2], pk)
+		if data.valid && err != nil {
+			t.Errorf("[%v] error while verifying key: %v", data.name, err)
+		}
+		if !data.valid && err == nil {
+			t.Errorf("[%v] invalid key passed validation", data.name)
+		}
+	}
+}
+
+func TestGenerateEd25519Token(t *testing.T) {
+	sk, err := unmarshalPrivateKeyFromString(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claims := jwt.StandardClaims{
+		Id:      "bar",
+		Subject: "foo",
+	}
+	_, err = jwt.NewWithClaims(SigningMethodEd25519i, claims).SignedString(sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func unmarshalPrivateKeyFromString(key string) (crypto.PrivKey, error) {
+	keyb, err := crypto.ConfigDecodeKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.UnmarshalPrivateKey(keyb)
+}
+
+func unmarshalPublicKeyFromString(key string) (crypto.PubKey, error) {
+	keyb, err := crypto.ConfigDecodeKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.UnmarshalPublicKey(keyb)
+}

--- a/jwt/session.go
+++ b/jwt/session.go
@@ -1,0 +1,158 @@
+package jwt
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/google/uuid"
+	crypto "github.com/libp2p/go-libp2p-core/crypto"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+	protocol "github.com/libp2p/go-libp2p-core/protocol"
+)
+
+var ErrClaimsInvalid = fmt.Errorf("claims invalid")
+var ErrNoToken = fmt.Errorf("no token found")
+var ErrExpired = fmt.Errorf("token expired")
+var ErrInvalid = fmt.Errorf("token invalid")
+
+type Claims struct {
+	Scope Scope `json:"scopes"`
+	jwt.StandardClaims
+}
+
+type Scope string
+
+const (
+	Access  Scope = "access"
+	Refresh Scope = "refresh"
+)
+
+type Session struct {
+	ID      string
+	Access  string
+	Exp     time.Time
+	Refresh string
+	Rexp    time.Time
+	Subject string
+	Type    string
+}
+
+func NewSession(sk crypto.PrivKey, pid peer.ID, proto protocol.ID, duration time.Duration) (*Session, error) {
+	issuer, err := peer.IDFromPrivateKey(sk)
+	if err != nil {
+		return nil, err
+	}
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return nil, err
+	}
+
+	// build access token
+	now := time.Now()
+	exp := now.Add(duration)
+	claims := &Claims{
+		Scope: Access,
+		StandardClaims: jwt.StandardClaims{
+			Audience:  string(proto),
+			ExpiresAt: exp.Unix(),
+			Id:        id.String(),
+			IssuedAt:  time.Now().Unix(),
+			Issuer:    issuer.Pretty(),
+			Subject:   pid.Pretty(),
+		},
+	}
+	access, err := jwt.NewWithClaims(SigningMethodEd25519i, claims).SignedString(sk)
+	if err != nil {
+		return nil, err
+	}
+
+	// build refresh token
+	rexp := now.Add(duration * 2)
+	rclaims := &Claims{
+		Scope: Refresh,
+		StandardClaims: jwt.StandardClaims{
+			Audience:  string(proto),
+			ExpiresAt: rexp.Unix(),
+			Id:        "r" + id.String(),
+			IssuedAt:  time.Now().Unix(),
+			Issuer:    issuer.Pretty(),
+			Subject:   pid.Pretty(),
+		},
+	}
+	refresh, err := jwt.NewWithClaims(SigningMethodEd25519i, rclaims).SignedString(sk)
+	if err != nil {
+		return nil, err
+	}
+
+	// build session
+	return &Session{
+		ID:      issuer.Pretty(),
+		Access:  access,
+		Exp:     exp,
+		Refresh: refresh,
+		Rexp:    rexp,
+		Subject: pid.Pretty(),
+		Type:    "JWT",
+	}, nil
+}
+
+func ParseClaims(claims jwt.Claims) (*Claims, error) {
+	mapClaims, ok := claims.(jwt.MapClaims)
+	if !ok {
+		return nil, ErrClaimsInvalid
+	}
+	claimsb, err := json.Marshal(mapClaims)
+	if err != nil {
+		return nil, ErrClaimsInvalid
+	}
+	var tclaims *Claims
+	if err := json.Unmarshal(claimsb, &tclaims); err != nil {
+		return nil, ErrClaimsInvalid
+	}
+	return tclaims, nil
+}
+
+func Validate(tokenString string, keyfunc jwt.Keyfunc, refreshing bool, audience string, subject *string) (*Claims, error) {
+	token, pErr := jwt.Parse(tokenString, keyfunc)
+	if token == nil {
+		return nil, ErrNoToken
+	}
+
+	claims, err := ParseClaims(token.Claims)
+	if err != nil {
+		return nil, ErrInvalid
+	}
+
+	if pErr != nil {
+		if !claims.VerifyExpiresAt(time.Now().Unix(), true) {
+			return nil, ErrExpired
+		}
+		return nil, ErrInvalid
+	}
+
+	switch claims.Scope {
+	case Access:
+		if refreshing {
+			return nil, ErrInvalid
+		}
+	case Refresh:
+		if !refreshing {
+			return nil, ErrInvalid
+		}
+	default:
+		return nil, ErrInvalid
+	}
+
+	// verify owner
+	if subject != nil && *subject != claims.Subject {
+		return nil, ErrInvalid
+	}
+
+	// verify protocol
+	if !claims.VerifyAudience(audience, true) {
+		return nil, ErrInvalid
+	}
+	return claims, nil
+}


### PR DESCRIPTION
We'll need this signing method to work with JWTs signed by peer keys. I included the session handling as well as a good starting place, though it will need some cleanup to work in the new world.